### PR TITLE
initial Dockerfile from assignment 1: Create a Dockerfile for a given…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+1_dockerfile/run_build.sh
+1_dockerfile/run_test.sh

--- a/1_dockerfile/Dockerfile
+++ b/1_dockerfile/Dockerfile
@@ -1,0 +1,24 @@
+# base image
+FROM golang:1.22.0-alpine3.18 as base
+WORKDIR /builder
+RUN apk add upx
+
+ENV GO111MODULE=on CGO_ENABLED=0
+
+COPY go.mod go.sum /builder/
+RUN go mod download
+
+COPY . .
+
+RUN go build \
+    -ldflags "-s -w" \
+    -o /builder/main /builder/main.go
+RUN upx -9 /builder/main
+
+# runner image
+FROM gcr.io/distroless/static:latest
+WORKDIR /app
+COPY --from=base /builder/main main
+
+EXPOSE 8080
+CMD ["/app/main"]

--- a/1_dockerfile/README.md
+++ b/1_dockerfile/README.md
@@ -1,0 +1,37 @@
+
+# Create a Dockerfile for a given application
+
+I'm separate section build and runnner with Multistage Dockerfile and use upx to reduce image size and use distroless for run application with static state
+
+if build with normal Dockerfile without alpine base image size will huge more than 9xx MB
+and then use alpine image still large more than 3xx MB
+until multistage image size ruduce to 1x MB
+final with upx and distroless and ldflags latest size is 4MB
+```
+# base image
+FROM golang:1.22.0-alpine3.18 as base
+WORKDIR /builder
+RUN apk add upx
+
+ENV GO111MODULE=on CGO_ENABLED=0
+
+COPY go.mod go.sum /builder/
+RUN go mod download
+
+COPY . .
+
+RUN go build \
+    -ldflags "-s -w" \
+    -o /builder/main /builder/main.go
+RUN upx -9 /builder/main
+
+# runner image
+FROM gcr.io/distroless/static:latest
+WORKDIR /app
+COPY --from=base /builder/main main
+
+EXPOSE 8080
+CMD ["/app/main"]
+```
+## Reference
+reduce size technique : https://clavinjune.dev/en/blogs/how-to-minimize-go-apps-container-image/

--- a/1_dockerfile/go.mod
+++ b/1_dockerfile/go.mod
@@ -1,0 +1,5 @@
+module test
+
+go 1.20
+
+require github.com/gorilla/mux v1.8.0

--- a/1_dockerfile/go.sum
+++ b/1_dockerfile/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/1_dockerfile/main.go
+++ b/1_dockerfile/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	name := query.Get("name")
+	if name == "" {
+		name = "World3"
+	}
+	log.Printf("Received request for %s\n", name)
+	w.Write([]byte(fmt.Sprintf("Hello, %s\n", name)))
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func readinessHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	// Create Server and Route Handlers
+	r := mux.NewRouter()
+
+	r.HandleFunc("/", handler)
+	r.HandleFunc("/health", healthHandler)
+	r.HandleFunc("/readiness", readinessHandler)
+
+	srv := &http.Server{
+		Handler:      r,
+		Addr:         ":8080",
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	// Start Server
+	go func() {
+		log.Println("Starting Server")
+		if err := srv.ListenAndServe(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// Graceful Shutdown
+	waitForShutdown(srv)
+}
+
+func waitForShutdown(srv *http.Server) {
+	interruptChan := make(chan os.Signal, 1)
+	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	// Block until we receive our signal.
+	<-interruptChan
+
+	// Create a deadline to wait for.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	srv.Shutdown(ctx)
+
+	log.Println("Shutting down")
+	os.Exit(0)
+}


### PR DESCRIPTION

# Create a Dockerfile for a given application

I'm separate section build and runnner with Multistage Dockerfile and use upx to reduce image size and use distroless for run application with static state

if build with normal Dockerfile without alpine base image size will huge more than 9xx MB
and then use alpine image still large more than 3xx MB
until multistage image size ruduce to 1x MB
final with upx and distroless and ldflags latest size is 4MB
```
# base image
FROM golang:1.22.0-alpine3.18 as base
WORKDIR /builder
RUN apk add upx

ENV GO111MODULE=on CGO_ENABLED=0

COPY go.mod go.sum /builder/
RUN go mod download

COPY . .

RUN go build \
    -ldflags "-s -w" \
    -o /builder/main /builder/main.go
RUN upx -9 /builder/main

# runner image
FROM gcr.io/distroless/static:latest
WORKDIR /app
COPY --from=base /builder/main main

EXPOSE 8080
CMD ["/app/main"]
```
## Reference
reduce size technique : https://clavinjune.dev/en/blogs/how-to-minimize-go-apps-container-image/